### PR TITLE
feat: add daily integration tests against live council websites

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,53 @@
+name: Integration Tests
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Run integration tests
+        id: tests
+        run: uv run --extra integration pytest tests/integration/ -v
+
+      - name: Open issue on failure
+        if: failure() && steps.tests.outcome == 'failure' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Ensure label exists
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'integration-failure',
+                color: 'd93f0b',
+              });
+            } catch (e) {
+              if (!e.message.includes('already_exists')) throw e;
+            }
+
+            // Only open one issue at a time — don't spam if already open
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'integration-failure',
+              state: 'open',
+            });
+            if (existing.data.length > 0) return;
+
+            const date = new Date().toISOString().slice(0, 10);
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Integration tests failed (${date})`,
+              body: `One or more council integrations are broken. Check the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.\n\nThis issue was opened automatically by the daily integration test run.`,
+              labels: ['integration-failure'],
+            });

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 RUFF_VERSION ?= 0.15.9
 RUFF = docker run --rm -v "$(PWD)":/src -w /src ghcr.io/astral-sh/ruff:$(RUFF_VERSION)
 
-.PHONY: lint format test
+.PHONY: lint format test test-integration
 
 lint:
 	$(RUFF) check .
@@ -11,4 +11,7 @@ format:
 	$(RUFF) format .
 
 test:
-	uv run --extra dev pytest tests/ -v
+	uv run --extra dev pytest tests/ --ignore=tests/integration/ -v
+
+test-integration:
+	uv run --extra integration pytest tests/integration/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = ["pytest"]
+integration = ["pytest", "pytest-asyncio", "aiohttp"]
 
 [tool.ruff]
 target-version = "py312"
@@ -28,6 +29,8 @@ known-first-party = ["custom_components.scottish_bins"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
+markers = ["integration: requires live network access to council websites (scheduled CI only)"]
 
 [tool.pyright]
 pythonVersion = "3.12"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,11 @@
+"""Shared fixtures for integration tests."""
+
+import aiohttp
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def session():
+    timeout = aiohttp.ClientTimeout(total=60)
+    async with aiohttp.ClientSession(timeout=timeout) as s:
+        yield s

--- a/tests/integration/test_live_councils.py
+++ b/tests/integration/test_live_councils.py
@@ -1,0 +1,85 @@
+"""Integration tests: real HTTP requests against live council websites.
+
+Each test performs the full property-search → collection-fetch flow for one
+council using a known residential postcode/address. Failures here mean the
+council's website or API has changed and the integration needs updating.
+
+Run with: uv run --extra integration pytest tests/integration/ -v
+"""
+
+import pytest
+
+from custom_components.scottish_bins.coordinator import (
+    _fetch_clackmannanshire,
+    _fetch_east_dunbartonshire,
+    _fetch_east_renfrewshire,
+    _fetch_falkirk,
+    _fetch_north_ayrshire,
+    _fetch_south_ayrshire,
+    _fetch_west_lothian,
+    fetch_clackmannanshire_properties,
+    fetch_east_dunbartonshire_uprns,
+    fetch_east_renfrewshire_properties,
+    fetch_falkirk_properties,
+    fetch_north_ayrshire_uprns,
+    fetch_south_ayrshire_properties,
+    fetch_west_lothian_properties,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def test_east_dunbartonshire(session):
+    properties = await fetch_east_dunbartonshire_uprns(session, "Bearsden")
+    assert properties, "No properties found for East Dunbartonshire"
+    uprn = properties[0]["uprn"]
+    collections = await _fetch_east_dunbartonshire(session, uprn)
+    assert collections, f"No bin collections for East Dunbartonshire UPRN {uprn}"
+
+
+async def test_clackmannanshire(session):
+    properties = await fetch_clackmannanshire_properties(session, "FK10 1HA")
+    assert properties, "No properties found for Clackmannanshire"
+    property_id, _ = properties[0]
+    collections = await _fetch_clackmannanshire(session, property_id)
+    assert collections, f"No bin collections for Clackmannanshire property {property_id}"
+
+
+async def test_falkirk(session):
+    properties = await fetch_falkirk_properties(session, "FK1 1JH")
+    assert properties, "No properties found for Falkirk"
+    uprn, _ = properties[0]
+    collections = await _fetch_falkirk(session, uprn)
+    assert collections, f"No bin collections for Falkirk UPRN {uprn}"
+
+
+async def test_north_ayrshire(session):
+    properties = await fetch_north_ayrshire_uprns(session, "KA12 8EE")
+    assert properties, "No properties found for North Ayrshire"
+    uprn, _ = properties[0]
+    collections = await _fetch_north_ayrshire(session, uprn)
+    assert collections, f"No bin collections for North Ayrshire UPRN {uprn}"
+
+
+async def test_west_lothian(session):
+    properties = await fetch_west_lothian_properties(session, "EH54 5AG")
+    assert properties, "No properties found for West Lothian"
+    uprn, _ = properties[0]
+    collections = await _fetch_west_lothian(session, uprn)
+    assert collections, f"No bin collections for West Lothian UPRN {uprn}"
+
+
+async def test_east_renfrewshire(session):
+    properties = await fetch_east_renfrewshire_properties(session, "G77 6QF")
+    assert properties, "No properties found for East Renfrewshire"
+    uprn, address = properties[0]
+    collections = await _fetch_east_renfrewshire(session, uprn, address)
+    assert collections, f"No bin collections for East Renfrewshire UPRN {uprn}"
+
+
+async def test_south_ayrshire(session):
+    properties = await fetch_south_ayrshire_properties(session, "KA8 0NE")
+    assert properties, "No properties found for South Ayrshire"
+    uprn, address = properties[0]
+    collections = await _fetch_south_ayrshire(session, uprn, address)
+    assert collections, f"No bin collections for South Ayrshire UPRN {uprn}"


### PR DESCRIPTION
## Summary

- Adds `tests/integration/test_live_councils.py` with one test per council — each does the full property-search → collection-fetch flow using a known residential postcode
- Adds `.github/workflows/integration.yml` scheduled to run daily at 08:00 UTC; also manually triggerable via `workflow_dispatch`
- On failure (schedule only), automatically opens a GitHub issue tagged `integration-failure` — deduplicates so only one open issue at a time
- `make test` now ignores `tests/integration/` so unit tests never hit the network
- `make test-integration` runs the live tests locally

## Test postcodes used

| Council | Query |
|---------|-------|
| East Dunbartonshire | `"Bearsden"` |
| Clackmannanshire | `FK10 1HA` |
| Falkirk | `FK1 1JH` |
| North Ayrshire | `KA12 8EE` |
| West Lothian | `EH54 5AG` |
| East Renfrewshire | `G77 6QF` |
| South Ayrshire | `KA8 0NE` |

## Test plan

- [ ] CI lint/hassfest/HACS checks pass
- [ ] Manually trigger the integration workflow to verify live tests pass