### PR TITLE
chore: reduce poll interval to 24h

### DIFF
--- a/custom_components/scottish_bins/coordinator.py
+++ b/custom_components/scottish_bins/coordinator.py
@@ -80,7 +80,7 @@ class ScottishBinsCoordinator(DataUpdateCoordinator[list[BinCollection]]):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(hours=6),
+            update_interval=timedelta(hours=24),
         )
         self._entry = entry
         self.session = async_get_clientsession(hass)


### PR DESCRIPTION
Bin collection schedules don't change during the day. 24h is sufficient and avoids unnecessary load on council websites.