### PR TITLE
feat: school holidays calendars and sensors

### DIFF
--- a/custom_components/east_dunbartonshire/__init__.py
+++ b/custom_components/east_dunbartonshire/__init__.py
@@ -8,19 +8,34 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import EastDunbartonshireCoordinator
+from .school_holidays import SchoolHolidaysCoordinator
 
-PLATFORMS: list[Platform] = [Platform.CALENDAR, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    coordinator = EastDunbartonshireCoordinator(hass, entry)
-    await coordinator.async_config_entry_first_refresh()
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    domain_data = hass.data.setdefault(DOMAIN, {})
+
+    # Bins coordinator — per config entry (per address)
+    bins_coordinator = EastDunbartonshireCoordinator(hass, entry)
+    await bins_coordinator.async_config_entry_first_refresh()
+    domain_data[entry.entry_id] = bins_coordinator
+
+    # School holidays coordinator — shared across all entries, set up once
+    if "school_holidays" not in domain_data:
+        school_coordinator = SchoolHolidaysCoordinator(hass)
+        await school_coordinator.async_config_entry_first_refresh()
+        domain_data["school_holidays"] = school_coordinator
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        domain_data = hass.data[DOMAIN]
+        domain_data.pop(entry.entry_id)
+        # Remove shared coordinator only when the last entry is removed
+        if not any(k for k in domain_data if k != "school_holidays"):
+            domain_data.pop("school_holidays", None)
     return unload_ok

--- a/custom_components/east_dunbartonshire/binary_sensor.py
+++ b/custom_components/east_dunbartonshire/binary_sensor.py
@@ -1,0 +1,71 @@
+"""Binary sensor platform for the East Dunbartonshire integration."""
+
+from __future__ import annotations
+
+import datetime
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .school_holidays import SchoolHolidaysCoordinator
+
+_SCHOOL_DEVICE = DeviceInfo(
+    identifiers={(DOMAIN, "east_dunbartonshire_school_holidays")},
+    name="East Dunbartonshire Schools",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    data = hass.data[DOMAIN]
+    if "school_holidays" not in data:
+        return
+    sc: SchoolHolidaysCoordinator = data["school_holidays"]
+    async_add_entities(
+        [
+            SchoolHolidayTodaySensor(sc),
+            InServiceDayTodaySensor(sc),
+        ]
+    )
+
+
+class SchoolHolidayTodaySensor(CoordinatorEntity[SchoolHolidaysCoordinator], BinarySensorEntity):
+    _attr_has_entity_name = True
+    _attr_name = "School holiday today"
+    _attr_unique_id = "east_dunbartonshire_school_holiday_today"
+    _attr_device_info = _SCHOOL_DEVICE
+
+    @property
+    def is_on(self) -> bool:
+        if not self.coordinator.data:
+            return False
+        today = datetime.date.today()
+        return any(
+            e.start <= today < e.end
+            for e in self.coordinator.data.events
+            if not e.is_in_service_day
+        )
+
+
+class InServiceDayTodaySensor(CoordinatorEntity[SchoolHolidaysCoordinator], BinarySensorEntity):
+    _attr_has_entity_name = True
+    _attr_name = "In-service day today"
+    _attr_unique_id = "east_dunbartonshire_in_service_day_today"
+    _attr_device_info = _SCHOOL_DEVICE
+
+    @property
+    def is_on(self) -> bool:
+        if not self.coordinator.data:
+            return False
+        today = datetime.date.today()
+        return any(
+            e.start <= today < e.end for e in self.coordinator.data.events if e.is_in_service_day
+        )

--- a/custom_components/east_dunbartonshire/calendar.py
+++ b/custom_components/east_dunbartonshire/calendar.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import BinCollection, EastDunbartonshireCoordinator
+from .school_holidays import SchoolHolidayEvent, SchoolHolidaysCoordinator
 
 
 async def async_setup_entry(
@@ -20,11 +21,22 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    coordinator: EastDunbartonshireCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([EastDunbartonshireCalendar(coordinator, entry)])
+    data = hass.data[DOMAIN]
+    entities: list[CalendarEntity] = [BinCollectionsCalendar(data[entry.entry_id], entry)]
+    if "school_holidays" in data:
+        entities += [
+            SchoolHolidaysCalendar(data["school_holidays"]),
+            InServiceDaysCalendar(data["school_holidays"]),
+        ]
+    async_add_entities(entities)
 
 
-class EastDunbartonshireCalendar(CoordinatorEntity[EastDunbartonshireCoordinator], CalendarEntity):
+# ---------------------------------------------------------------------------
+# Bin collections
+# ---------------------------------------------------------------------------
+
+
+class BinCollectionsCalendar(CoordinatorEntity[EastDunbartonshireCoordinator], CalendarEntity):
     _attr_has_entity_name = True
     _attr_name = "Bin collections"
 
@@ -44,7 +56,7 @@ class EastDunbartonshireCalendar(CoordinatorEntity[EastDunbartonshireCoordinator
         upcoming = [c for c in self.coordinator.data if c.next_date >= today]
         if not upcoming:
             return None
-        return _make_event(min(upcoming, key=lambda c: c.next_date))
+        return _make_bin_event(min(upcoming, key=lambda c: c.next_date))
 
     async def async_get_events(
         self,
@@ -56,12 +68,82 @@ class EastDunbartonshireCalendar(CoordinatorEntity[EastDunbartonshireCoordinator
             return []
         start = start_date.date()
         end = end_date.date()
-        return [_make_event(c) for c in self.coordinator.data if start <= c.next_date < end]
+        return [_make_bin_event(c) for c in self.coordinator.data if start <= c.next_date < end]
 
 
-def _make_event(collection: BinCollection) -> CalendarEvent:
+def _make_bin_event(collection: BinCollection) -> CalendarEvent:
     return CalendarEvent(
         start=collection.next_date,
         end=collection.next_date + datetime.timedelta(days=1),
         summary=f"{collection.name} collection",
+    )
+
+
+# ---------------------------------------------------------------------------
+# School holidays
+# ---------------------------------------------------------------------------
+
+
+class _SchoolCalendarBase(CoordinatorEntity[SchoolHolidaysCoordinator], CalendarEntity):
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: SchoolHolidaysCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, "east_dunbartonshire_school_holidays")},
+            name="East Dunbartonshire Schools",
+        )
+
+    def _relevant_events(self) -> list[SchoolHolidayEvent]:
+        raise NotImplementedError
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        today = datetime.date.today()
+        for e in self._relevant_events():
+            if e.start <= today < e.end:
+                return _make_school_event(e)
+        upcoming = [e for e in self._relevant_events() if e.start > today]
+        return _make_school_event(upcoming[0]) if upcoming else None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[CalendarEvent]:
+        start = start_date.date()
+        end = end_date.date()
+        return [
+            _make_school_event(e)
+            for e in self._relevant_events()
+            if e.start < end and e.end > start
+        ]
+
+
+class SchoolHolidaysCalendar(_SchoolCalendarBase):
+    _attr_name = "School holidays"
+    _attr_unique_id = "east_dunbartonshire_school_holidays_calendar"
+
+    def _relevant_events(self) -> list[SchoolHolidayEvent]:
+        if not self.coordinator.data:
+            return []
+        return [e for e in self.coordinator.data.events if not e.is_in_service_day]
+
+
+class InServiceDaysCalendar(_SchoolCalendarBase):
+    _attr_name = "In-service days"
+    _attr_unique_id = "east_dunbartonshire_in_service_days_calendar"
+
+    def _relevant_events(self) -> list[SchoolHolidayEvent]:
+        if not self.coordinator.data:
+            return []
+        return [e for e in self.coordinator.data.events if e.is_in_service_day]
+
+
+def _make_school_event(event: SchoolHolidayEvent) -> CalendarEvent:
+    return CalendarEvent(
+        start=event.start,
+        end=event.end,
+        summary=event.summary,
     )

--- a/custom_components/east_dunbartonshire/school_holidays.py
+++ b/custom_components/east_dunbartonshire/school_holidays.py
@@ -1,0 +1,115 @@
+"""School holidays data for East Dunbartonshire."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+_LOGGER = logging.getLogger(__name__)
+
+SCHOOL_HOLIDAYS_PAGE_URL = (
+    "https://www.eastdunbarton.gov.uk/services/a-z-of-services/"
+    "primary-secondary-and-early-years-education/school-holidays/"
+)
+
+_IN_SERVICE_KEYWORDS = ("in-service", "teachers return")
+
+
+@dataclass
+class SchoolHolidayEvent:
+    summary: str
+    start: date
+    end: date  # exclusive end per iCal convention
+    is_in_service_day: bool
+
+    @property
+    def inclusive_end(self) -> date:
+        return self.end - timedelta(days=1)
+
+
+@dataclass
+class SchoolHolidaysData:
+    events: list[SchoolHolidayEvent]
+    available_years: list[str]  # e.g. ["25-26", "26-27"]
+
+
+class SchoolHolidaysCoordinator(DataUpdateCoordinator[SchoolHolidaysData]):
+    def __init__(self, hass: HomeAssistant) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="east_dunbartonshire_school_holidays",
+            update_interval=timedelta(hours=24),
+        )
+        self.session = async_get_clientsession(hass)
+
+    async def _async_update_data(self) -> SchoolHolidaysData:
+        try:
+            return await _fetch_school_holidays(self.session)
+        except Exception as err:
+            raise UpdateFailed(f"Error fetching school holidays: {err}") from err
+
+
+async def _fetch_school_holidays(session) -> SchoolHolidaysData:
+    async with session.get(SCHOOL_HOLIDAYS_PAGE_URL) as resp:
+        resp.raise_for_status()
+        html = await resp.text()
+
+    ics_urls = re.findall(r'href="([^"]+school-holidays[^"]+\.ics)"', html, re.IGNORECASE)
+    # Make absolute
+    ics_urls = [
+        u if u.startswith("http") else f"https://www.eastdunbarton.gov.uk{u}" for u in ics_urls
+    ]
+
+    available_years = [_year_from_url(u) for u in ics_urls]
+
+    events: list[SchoolHolidayEvent] = []
+    for url in ics_urls:
+        async with session.get(url) as resp:
+            resp.raise_for_status()
+            ics_text = await resp.text()
+        events.extend(_parse_ics(ics_text))
+
+    events.sort(key=lambda e: e.start)
+    return SchoolHolidaysData(events=events, available_years=available_years)
+
+
+def _year_from_url(url: str) -> str:
+    m = re.search(r"school-holidays-(\d{2}-\d{2})", url, re.IGNORECASE)
+    return m.group(1) if m else url
+
+
+def _parse_ics(ics_text: str) -> list[SchoolHolidayEvent]:
+    events = []
+    for block in re.findall(r"BEGIN:VEVENT(.*?)END:VEVENT", ics_text, re.DOTALL):
+        summary_m = re.search(r"SUMMARY:(.*)", block)
+        start_m = re.search(r"DTSTART(?:;VALUE=DATE)?:(\d{8})", block)
+        end_m = re.search(r"DTEND(?:;VALUE=DATE)?:(\d{8})", block)
+
+        if not (summary_m and start_m):
+            continue
+
+        summary = summary_m.group(1).strip()
+        start = _parse_date(start_m.group(1))
+        end = _parse_date(end_m.group(1)) if end_m else start + timedelta(days=1)
+
+        is_in_service = any(k in summary.lower() for k in _IN_SERVICE_KEYWORDS)
+        events.append(
+            SchoolHolidayEvent(
+                summary=summary,
+                start=start,
+                end=end,
+                is_in_service_day=is_in_service,
+            )
+        )
+    return events
+
+
+def _parse_date(s: str) -> date:
+    return datetime.strptime(s[:8], "%Y%m%d").date()

--- a/custom_components/east_dunbartonshire/sensor.py
+++ b/custom_components/east_dunbartonshire/sensor.py
@@ -13,6 +13,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import BIN_TYPES, DOMAIN
 from .coordinator import EastDunbartonshireCoordinator
+from .school_holidays import SchoolHolidaysCoordinator
+
+_SCHOOL_DEVICE = DeviceInfo(
+    identifiers={(DOMAIN, "east_dunbartonshire_school_holidays")},
+    name="East Dunbartonshire Schools",
+)
 
 
 async def async_setup_entry(
@@ -20,10 +26,19 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    coordinator: EastDunbartonshireCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        [BinSensor(coordinator, entry, bin_class, name) for bin_class, name in BIN_TYPES.items()]
-    )
+    data = hass.data[DOMAIN]
+    coordinator: EastDunbartonshireCoordinator = data[entry.entry_id]
+    entities: list[SensorEntity] = [
+        BinSensor(coordinator, entry, bin_class, name) for bin_class, name in BIN_TYPES.items()
+    ]
+    if "school_holidays" in data:
+        entities.append(SchoolHolidayYearsSensor(data["school_holidays"]))
+    async_add_entities(entities)
+
+
+# ---------------------------------------------------------------------------
+# Bin sensors
+# ---------------------------------------------------------------------------
 
 
 class BinSensor(CoordinatorEntity[EastDunbartonshireCoordinator], SensorEntity):
@@ -64,3 +79,23 @@ class BinSensor(CoordinatorEntity[EastDunbartonshireCoordinator], SensorEntity):
                 days = (collection.next_date - datetime.date.today()).days
                 return {"days_until": days}
         return {}
+
+
+# ---------------------------------------------------------------------------
+# School holiday sensors
+# ---------------------------------------------------------------------------
+
+
+class SchoolHolidayYearsSensor(CoordinatorEntity[SchoolHolidaysCoordinator], SensorEntity):
+    """Tracks which academic years' data is available. Automating on state change detects new releases."""
+
+    _attr_has_entity_name = True
+    _attr_name = "School holiday years available"
+    _attr_unique_id = "east_dunbartonshire_school_holiday_years"
+    _attr_device_info = _SCHOOL_DEVICE
+
+    @property
+    def native_value(self) -> str | None:
+        if not self.coordinator.data:
+            return None
+        return ", ".join(self.coordinator.data.available_years)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
     "name": "East Dunbartonshire",
-    "render_readme": true,
-    "content_in_root": false
+    "render_readme": true
 }


### PR DESCRIPTION
Closes #43

## New entities

**Calendars**
- `calendar.school_holidays` — school holiday breaks (excludes in-service days)
- `calendar.in_service_days` — teacher in-service days only

**Binary sensors**
- `binary_sensor.school_holiday_today` — on during school holidays
- `binary_sensor.in_service_day_today` — on on in-service days

**Sensor**
- `sensor.school_holiday_years_available` — e.g. `"25-26, 26-27"`; state changes when a new academic year's ICS is published, so you can automate on it to get notified when 2027/28 drops

## Implementation notes

- Scrapes the school holidays page to discover ICS links, so new years are picked up automatically
- School holidays coordinator is shared across config entries (one instance regardless of how many addresses you've configured)
- Refresh: every 24 hours