### PR TITLE
feat: road works sensors from SRWR

### DIFF
--- a/custom_components/east_dunbartonshire/__init__.py
+++ b/custom_components/east_dunbartonshire/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import EastDunbartonshireCoordinator
+from .road_works import RoadWorksCoordinator
 from .school_holidays import SchoolHolidaysCoordinator
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.SENSOR]
@@ -21,11 +22,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await bins_coordinator.async_config_entry_first_refresh()
     domain_data[entry.entry_id] = bins_coordinator
 
-    # School holidays coordinator — shared across all entries, set up once
+    # School holidays and road works coordinators — shared across all entries, set up once
     if "school_holidays" not in domain_data:
         school_coordinator = SchoolHolidaysCoordinator(hass)
         await school_coordinator.async_config_entry_first_refresh()
         domain_data["school_holidays"] = school_coordinator
+
+    if "road_works" not in domain_data:
+        road_works_coordinator = RoadWorksCoordinator(hass)
+        await road_works_coordinator.async_config_entry_first_refresh()
+        domain_data["road_works"] = road_works_coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -35,7 +41,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         domain_data = hass.data[DOMAIN]
         domain_data.pop(entry.entry_id)
-        # Remove shared coordinator only when the last entry is removed
-        if not any(k for k in domain_data if k != "school_holidays"):
+        # Remove shared coordinators only when the last entry is removed
+        if not any(k for k in domain_data if k not in ("school_holidays", "road_works")):
             domain_data.pop("school_holidays", None)
+            domain_data.pop("road_works", None)
     return unload_ok

--- a/custom_components/east_dunbartonshire/road_works.py
+++ b/custom_components/east_dunbartonshire/road_works.py
@@ -1,0 +1,161 @@
+"""Scottish Road Works Register (SRWR) data for East Dunbartonshire."""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import zipfile
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+_LOGGER = logging.getLogger(__name__)
+
+_SRWR_DAILY_URL = "https://downloads.srwr.scot/export/daily/"
+_ED_AUTHORITY = "East Dunbartonshire"
+
+# Works that are expected to be present today
+_ACTIVE_STATUSES = {
+    "In Progress",
+    "Proposed",
+    "Immediate - Urgent",
+    "Immediate - Emergency",
+}
+
+
+@dataclass
+class RoadWork:
+    reference: str
+    street_name: str
+    area: str
+    promoter: str
+    works_type: str
+    start_date: date | None
+    end_date: date | None
+    status: str
+    description: str
+
+
+@dataclass
+class RoadWorksData:
+    active: list[RoadWork] = field(default_factory=list)
+    upcoming: list[RoadWork] = field(default_factory=list)
+
+
+class RoadWorksCoordinator(DataUpdateCoordinator[RoadWorksData]):
+    def __init__(self, hass: HomeAssistant) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="east_dunbartonshire_road_works",
+            update_interval=timedelta(hours=12),
+        )
+        self.session = async_get_clientsession(hass)
+
+    async def _async_update_data(self) -> RoadWorksData:
+        try:
+            return await _fetch_road_works(self.session)
+        except Exception as err:
+            raise UpdateFailed(f"Error fetching road works: {err}") from err
+
+
+async def _fetch_road_works(session) -> RoadWorksData:
+    zip_url = await _find_daily_zip(session)
+    async with session.get(zip_url) as resp:
+        resp.raise_for_status()
+        raw = await resp.read()
+
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        csv_name = next((n for n in zf.namelist() if n.endswith(".csv")), None)
+        if not csv_name:
+            raise UpdateFailed("No CSV found in SRWR daily ZIP")
+        csv_bytes = zf.read(csv_name)
+
+    rows = _parse_csv(csv_bytes.decode("utf-8-sig", errors="replace"))
+
+    today = datetime.now().date()
+    active: list[RoadWork] = []
+    upcoming: list[RoadWork] = []
+
+    for row in rows:
+        if (
+            row.start_date
+            and row.start_date <= today
+            and (row.end_date is None or row.end_date >= today)
+        ):
+            active.append(row)
+        elif row.start_date and row.start_date > today:
+            upcoming.append(row)
+
+    active.sort(key=lambda r: r.start_date or date.min)
+    upcoming.sort(key=lambda r: r.start_date or date.min)
+    return RoadWorksData(active=active, upcoming=upcoming[:20])
+
+
+async def _find_daily_zip(session) -> str:
+    async with session.get(_SRWR_DAILY_URL) as resp:
+        resp.raise_for_status()
+        html = await resp.text()
+
+    import re
+
+    matches = re.findall(r'href="([^"]*\.zip)"', html, re.IGNORECASE)
+    if not matches:
+        raise UpdateFailed("No ZIP file found at SRWR daily export listing")
+    url = matches[-1]
+    if not url.startswith("http"):
+        url = f"https://downloads.srwr.scot{url}"
+    return url
+
+
+def _parse_csv(text: str) -> list[RoadWork]:
+    works = []
+    reader = csv.DictReader(io.StringIO(text))
+    for row in reader:
+        authority = _col(row, "highway_authority", "promoter_organisation", "works_authority")
+        if _ED_AUTHORITY.lower() not in authority.lower():
+            continue
+
+        start = _parse_date(_col(row, "works_start_date", "date_of_works", "start_date"))
+        end = _parse_date(_col(row, "works_end_date", "end_date", "date_of_completion"))
+        works.append(
+            RoadWork(
+                reference=_col(row, "works_reference_number", "reference", "work_ref"),
+                street_name=_col(row, "street_name", "road_name", "street"),
+                area=_col(row, "town", "location", "area"),
+                promoter=_col(row, "promoter_organisation", "works_promoter", "promoter"),
+                works_type=_col(row, "activity_type", "works_type", "work_type"),
+                start_date=start,
+                end_date=end,
+                status=_col(row, "works_status", "status"),
+                description=_col(row, "works_description", "description", "proposed_works"),
+            )
+        )
+    return works
+
+
+def _col(row: dict, *keys: str) -> str:
+    for key in keys:
+        val = row.get(key, "").strip()
+        if val:
+            return val
+        # case-insensitive fallback
+        for k, v in row.items():
+            if k.lower() == key.lower() and v.strip():
+                return v.strip()
+    return ""
+
+
+def _parse_date(s: str) -> date | None:
+    if not s:
+        return None
+    for fmt in ("%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y", "%Y%m%d"):
+        try:
+            return datetime.strptime(s[:10], fmt).date()
+        except ValueError:
+            continue
+    return None

--- a/custom_components/east_dunbartonshire/sensor.py
+++ b/custom_components/east_dunbartonshire/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import BIN_TYPES, DOMAIN
 from .coordinator import EastDunbartonshireCoordinator
+from .road_works import RoadWorksCoordinator
 from .school_holidays import SchoolHolidaysCoordinator
 
 _SCHOOL_DEVICE = DeviceInfo(
@@ -33,6 +34,11 @@ async def async_setup_entry(
     ]
     if "school_holidays" in data:
         entities.append(SchoolHolidayYearsSensor(data["school_holidays"]))
+    if "road_works" in data:
+        entities += [
+            ActiveRoadWorksSensor(data["road_works"]),
+            UpcomingRoadWorksSensor(data["road_works"]),
+        ]
     async_add_entities(entities)
 
 
@@ -99,3 +105,83 @@ class SchoolHolidayYearsSensor(CoordinatorEntity[SchoolHolidaysCoordinator], Sen
         if not self.coordinator.data:
             return None
         return ", ".join(self.coordinator.data.available_years)
+
+
+# ---------------------------------------------------------------------------
+# Road works sensors
+# ---------------------------------------------------------------------------
+
+_ROAD_WORKS_DEVICE = DeviceInfo(
+    identifiers={(DOMAIN, "east_dunbartonshire_road_works")},
+    name="East Dunbartonshire Road Works",
+)
+
+
+class ActiveRoadWorksSensor(CoordinatorEntity[RoadWorksCoordinator], SensorEntity):
+    _attr_has_entity_name = True
+    _attr_name = "Active road works"
+    _attr_unique_id = "east_dunbartonshire_active_road_works"
+    _attr_native_unit_of_measurement = "works"
+    _attr_device_info = _ROAD_WORKS_DEVICE
+
+    @property
+    def native_value(self) -> int | None:
+        if not self.coordinator.data:
+            return None
+        return len(self.coordinator.data.active)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        if not self.coordinator.data:
+            return {}
+        return {
+            "works": [
+                {
+                    "reference": w.reference,
+                    "street": w.street_name,
+                    "area": w.area,
+                    "promoter": w.promoter,
+                    "type": w.works_type,
+                    "start_date": w.start_date.isoformat() if w.start_date else None,
+                    "end_date": w.end_date.isoformat() if w.end_date else None,
+                    "status": w.status,
+                    "description": w.description,
+                }
+                for w in self.coordinator.data.active[:20]
+            ]
+        }
+
+
+class UpcomingRoadWorksSensor(CoordinatorEntity[RoadWorksCoordinator], SensorEntity):
+    _attr_has_entity_name = True
+    _attr_name = "Upcoming road works"
+    _attr_unique_id = "east_dunbartonshire_upcoming_road_works"
+    _attr_native_unit_of_measurement = "works"
+    _attr_device_info = _ROAD_WORKS_DEVICE
+
+    @property
+    def native_value(self) -> int | None:
+        if not self.coordinator.data:
+            return None
+        return len(self.coordinator.data.upcoming)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        if not self.coordinator.data:
+            return {}
+        return {
+            "works": [
+                {
+                    "reference": w.reference,
+                    "street": w.street_name,
+                    "area": w.area,
+                    "promoter": w.promoter,
+                    "type": w.works_type,
+                    "start_date": w.start_date.isoformat() if w.start_date else None,
+                    "end_date": w.end_date.isoformat() if w.end_date else None,
+                    "status": w.status,
+                    "description": w.description,
+                }
+                for w in self.coordinator.data.upcoming
+            ]
+        }


### PR DESCRIPTION
## Summary

- Adds `sensor.east_dunbartonshire_active_road_works` and `sensor.east_dunbartonshire_upcoming_road_works`
- Downloads the Scottish Road Works Register (SRWR) daily ZIP from `downloads.srwr.scot`, extracts the CSV, and filters rows to East Dunbartonshire
- Active = works whose date range includes today; upcoming = future works (capped at 20)
- Each sensor's attributes contain a list of works with reference, street, area, promoter, type, dates, status, and description
- Shared coordinator (council-wide data), polls every 12 hours
- Robust CSV column lookup: tries multiple plausible column name variants to handle schema changes

## Test plan

- [ ] Confirm sensors appear after HA restart
- [ ] Check attributes contain road works entries with valid fields
- [ ] Verify only East Dunbartonshire works are returned