### PR TITLE
feat: planning application map pins via geo_location platform

### DIFF
--- a/custom_components/east_dunbartonshire/__init__.py
+++ b/custom_components/east_dunbartonshire/__init__.py
@@ -28,13 +28,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await school_coordinator.async_config_entry_first_refresh()
         domain_data["school_holidays"] = school_coordinator
 
-    # Planning coordinator — per entry (proximity is relative to the configured address)
-    address = entry.data.get(CONF_ADDRESS, "")
-    postcode = address.split(", ")[-1] if ", " in address else address
-    if postcode:
-        planning_coordinator = PlanningCoordinator(hass, postcode)
-        await planning_coordinator.async_config_entry_first_refresh()
-        domain_data[f"{entry.entry_id}_planning"] = planning_coordinator
+    # Planning coordinator — proximity is relative to the HA home location
+    planning_coordinator = PlanningCoordinator(
+        hass, hass.config.latitude, hass.config.longitude
+    )
+    await planning_coordinator.async_config_entry_first_refresh()
+    domain_data[f"{entry.entry_id}_planning"] = planning_coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/custom_components/east_dunbartonshire/__init__.py
+++ b/custom_components/east_dunbartonshire/__init__.py
@@ -6,12 +6,17 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_ADDRESS, DOMAIN
+from .const import DOMAIN
 from .coordinator import EastDunbartonshireCoordinator
 from .planning import PlanningCoordinator
 from .school_holidays import SchoolHolidaysCoordinator
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.CALENDAR,
+    Platform.GEO_LOCATION,
+    Platform.SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -29,9 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         domain_data["school_holidays"] = school_coordinator
 
     # Planning coordinator — proximity is relative to the HA home location
-    planning_coordinator = PlanningCoordinator(
-        hass, hass.config.latitude, hass.config.longitude
-    )
+    planning_coordinator = PlanningCoordinator(hass, hass.config.latitude, hass.config.longitude)
     await planning_coordinator.async_config_entry_first_refresh()
     domain_data[f"{entry.entry_id}_planning"] = planning_coordinator
 
@@ -44,6 +47,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         domain_data = hass.data[DOMAIN]
         domain_data.pop(entry.entry_id)
         domain_data.pop(f"{entry.entry_id}_planning", None)
+        domain_data.pop(f"{entry.entry_id}_planning_geo", None)
         # Remove shared coordinator only when the last entry is removed
         if not any(k for k in domain_data if k not in ("school_holidays",)):
             domain_data.pop("school_holidays", None)

--- a/custom_components/east_dunbartonshire/geo_location.py
+++ b/custom_components/east_dunbartonshire/geo_location.py
@@ -1,0 +1,115 @@
+"""Geo location platform for East Dunbartonshire planning applications."""
+
+from __future__ import annotations
+
+from homeassistant.components.geo_location import GeolocationEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .planning import PlanningApplication, PlanningCoordinator
+
+_SOURCE = "east_dunbartonshire_planning"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    data = hass.data[DOMAIN]
+    planning_key = f"{entry.entry_id}_planning"
+    if planning_key not in data:
+        return
+
+    coordinator: PlanningCoordinator = data[planning_key]
+    manager = _PlanningGeoManager(hass, coordinator, entry, async_add_entities)
+    data[f"{entry.entry_id}_planning_geo"] = manager
+    # Trigger initial population if data is already available
+    manager.async_handle_update()
+
+
+class _PlanningGeoManager:
+    """Manages the lifecycle of PlanningApplicationGeoLocation entities."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: PlanningCoordinator,
+        entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        self._hass = hass
+        self._coordinator = coordinator
+        self._entry = entry
+        self._async_add_entities = async_add_entities
+        self._entities: dict[str, PlanningApplicationGeoLocation] = {}
+        coordinator.async_add_listener(self.async_handle_update)
+
+    @callback
+    def async_handle_update(self) -> None:
+        if not self._coordinator.data:
+            return
+
+        new_apps = {
+            a.reference: a
+            for a in self._coordinator.data.applications
+            if a.latitude is not None and a.longitude is not None
+        }
+        current_refs = set(self._entities)
+
+        # Remove applications no longer nearby
+        for ref in current_refs - new_apps.keys():
+            entity = self._entities.pop(ref)
+            self._hass.async_create_task(entity.async_remove())
+
+        # Update existing entities
+        for ref in current_refs & new_apps.keys():
+            self._entities[ref].async_update_from_application(new_apps[ref])
+
+        # Add new applications
+        to_add = [
+            PlanningApplicationGeoLocation(app, self._entry)
+            for ref, app in new_apps.items()
+            if ref not in current_refs
+        ]
+        if to_add:
+            for entity in to_add:
+                self._entities[entity.unique_id or entity._app.reference] = entity
+            self._async_add_entities(to_add)
+
+
+class PlanningApplicationGeoLocation(GeolocationEvent):
+    """A single planning application shown as a map pin."""
+
+    _attr_should_poll = False
+    _attr_source = _SOURCE
+    _attr_has_entity_name = True
+
+    def __init__(self, app: PlanningApplication, entry: ConfigEntry) -> None:
+        self._app = app
+        self._attr_unique_id = f"{entry.entry_id}_geo_{app.reference}"
+        self._attr_name = app.reference
+        self._attr_latitude = app.latitude
+        self._attr_longitude = app.longitude
+        self._attr_distance = (app.distance_m or 0) / 1000.0  # km
+
+    @callback
+    def async_update_from_application(self, app: PlanningApplication) -> None:
+        self._app = app
+        self._attr_latitude = app.latitude
+        self._attr_longitude = app.longitude
+        self._attr_distance = (app.distance_m or 0) / 1000.0
+        self.async_write_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {
+            "address": self._app.address,
+            "description": self._app.description,
+            "date_modified": (
+                self._app.date_modified.isoformat() if self._app.date_modified else None
+            ),
+            "url": self._app.url,
+        }

--- a/custom_components/east_dunbartonshire/planning.py
+++ b/custom_components/east_dunbartonshire/planning.py
@@ -1,10 +1,10 @@
-"""Planning applications scraper for East Dunbartonshire (Idox portal)."""
+"""Planning applications for East Dunbartonshire via ArcGIS spatial query."""
 
 from __future__ import annotations
 
+import json
 import logging
 import math
-import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 
@@ -14,12 +14,16 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 _LOGGER = logging.getLogger(__name__)
 
-_IDOX_BASE = "https://planning.eastdunbarton.gov.uk/online-applications"
-_POSTCODES_IO = "https://api.postcodes.io"
-_SEARCH_DAYS = 90
+_ARCGIS_QUERY = (
+    "https://planning.eastdunbarton.gov.uk/server/rest/services/"
+    "PALIVE/LIVEUniformPA_Planning/FeatureServer/2/query"
+)
+_ARCGIS_REFERER = (
+    "https://planning.eastdunbarton.gov.uk/portal/apps/experiencebuilder/"
+    "experience/?id=fa77980e1f55476ba379d5553f6f9376"
+)
+_POSTCODES_IO_REVERSE = "https://api.postcodes.io/postcodes"
 DEFAULT_RADIUS_M = 500
-
-_UK_POSTCODE_RE = re.compile(r"\b([A-Z]{1,2}\d{1,2}[A-Z]?\s*\d[A-Z]{2})\b", re.IGNORECASE)
 
 
 @dataclass
@@ -27,8 +31,7 @@ class PlanningApplication:
     reference: str
     address: str
     description: str
-    date_received: date | None
-    status: str
+    date_modified: date | None
     url: str
     distance_m: int | None = None
 
@@ -41,7 +44,11 @@ class PlanningData:
 
 class PlanningCoordinator(DataUpdateCoordinator[PlanningData]):
     def __init__(
-        self, hass: HomeAssistant, home_postcode: str, radius_m: int = DEFAULT_RADIUS_M
+        self,
+        hass: HomeAssistant,
+        lat: float,
+        lon: float,
+        radius_m: int = DEFAULT_RADIUS_M,
     ) -> None:
         super().__init__(
             hass,
@@ -49,146 +56,110 @@ class PlanningCoordinator(DataUpdateCoordinator[PlanningData]):
             name="east_dunbartonshire_planning",
             update_interval=timedelta(hours=4),
         )
-        self.session = async_get_clientsession(hass)
-        self._home_postcode = home_postcode
+        self._lat = lat
+        self._lon = lon
         self._radius_m = radius_m
-        self._home_lat: float | None = None
-        self._home_lng: float | None = None
+        self._easting: int | None = None
+        self._northing: int | None = None
+        self.session = async_get_clientsession(hass)
 
     async def _async_update_data(self) -> PlanningData:
         try:
-            if self._home_lat is None:
-                self._home_lat, self._home_lng = await _geocode_postcode(
-                    self.session, self._home_postcode
+            if self._easting is None:
+                self._easting, self._northing = await _latlon_to_bng(
+                    self.session, self._lat, self._lon
                 )
-            home_lat: float = self._home_lat
-            home_lng: float = self._home_lng  # type: ignore[assignment]
-            return await _fetch_planning(self.session, home_lat, home_lng, self._radius_m)
+            return await _fetch_nearby(
+                self.session, self._easting, self._northing, self._radius_m
+            )
         except Exception as err:
             raise UpdateFailed(f"Error fetching planning applications: {err}") from err
 
 
-async def _geocode_postcode(session, postcode: str) -> tuple[float, float]:
-    url = f"{_POSTCODES_IO}/postcodes/{postcode.replace(' ', '%20')}"
-    async with session.get(url) as resp:
+async def _latlon_to_bng(session, lat: float, lon: float) -> tuple[int, int]:
+    """Convert WGS84 lat/lon to BNG easting/northing via postcodes.io nearest postcode."""
+    async with session.get(
+        _POSTCODES_IO_REVERSE, params={"lon": lon, "lat": lat, "limit": 1}
+    ) as resp:
         resp.raise_for_status()
         data = await resp.json()
-    r = data["result"]
-    return r["latitude"], r["longitude"]
+    results = data.get("result") or []
+    if not results:
+        raise ValueError(f"Could not convert ({lat}, {lon}) to BNG coordinates")
+    r = results[0]
+    return int(r["eastings"]), int(r["northings"])
 
 
-async def _fetch_planning(session, home_lat: float, home_lng: float, radius_m: int) -> PlanningData:
-    end_dt = datetime.now()
-    start_dt = end_dt - timedelta(days=_SEARCH_DAYS)
-    params = {
-        "searchType": "Application",
-        "date(applicationReceivedStart)": start_dt.strftime("%d/%m/%Y"),
-        "date(applicationReceivedEnd)": end_dt.strftime("%d/%m/%Y"),
-        "searchCriteria.caseStatus": "ALL",
-        "action": "firstPage",
-        "searchCriteria.page": "1",
+async def _fetch_nearby(
+    session, home_easting: int, home_northing: int, radius_m: int
+) -> PlanningData:
+    bbox = {
+        "xmin": home_easting - radius_m,
+        "ymin": home_northing - radius_m,
+        "xmax": home_easting + radius_m,
+        "ymax": home_northing + radius_m,
     }
-    async with session.get(f"{_IDOX_BASE}/advancedSearchResults.do", params=params) as resp:
+    params = {
+        "f": "json",
+        "geometry": json.dumps(bbox, separators=(",", ":")),
+        "geometryType": "esriGeometryEnvelope",
+        "inSR": "27700",
+        "outSR": "27700",
+        "spatialRel": "esriSpatialRelIntersects",
+        "where": "ISPAVISIBLE=1",
+        "outFields": "REFVAL,KEYVAL,ADDRESS,DESCRIPTION,DATEMODIFIED",
+        "returnGeometry": "false",
+        "returnCentroid": "true",
+        "returnExceededLimitFeatures": "false",
+    }
+    async with session.get(
+        _ARCGIS_QUERY, params=params, headers={"Referer": _ARCGIS_REFERER}
+    ) as resp:
         resp.raise_for_status()
-        html = await resp.text()
-
-    applications = _parse_results(html)
-
-    # Batch-geocode unique postcodes found in application addresses
-    postcodes = [_extract_postcode(app.address) for app in applications]
-    unique = list({p for p in postcodes if p})
-    coords_map = await _bulk_geocode(session, unique) if unique else {}
+        data = await resp.json()
 
     nearby = []
-    for app, pc in zip(applications, postcodes):
-        if not pc or pc not in coords_map:
+    for feature in data.get("features", []):
+        attrs = feature.get("attributes", {})
+        centroid = feature.get("centroid")
+        if not centroid:
             continue
-        lat, lng = coords_map[pc]
-        dist = _haversine_m(home_lat, home_lng, lat, lng)
-        if dist <= radius_m:
-            app.distance_m = round(dist)
+        dist = math.sqrt(
+            (centroid["x"] - home_easting) ** 2 + (centroid["y"] - home_northing) ** 2
+        )
+        if dist > radius_m:
+            continue
+        app = _parse_feature(attrs, round(dist))
+        if app:
             nearby.append(app)
 
-    nearby.sort(key=lambda a: a.date_received or date.min, reverse=True)
+    nearby.sort(key=lambda a: a.date_modified or date.min, reverse=True)
     return PlanningData(applications=nearby, search_radius_m=radius_m)
 
 
-def _parse_results(html: str) -> list[PlanningApplication]:
-    applications = []
-    for block in re.findall(
-        r'<li[^>]*class="[^"]*searchresult[^"]*"[^>]*>(.*?)</li>', html, re.DOTALL
-    ):
-        meta_m = re.search(r'class="metaInfo"[^>]*>(.*?)</p>', block, re.DOTALL)
-        addr_m = re.search(r'class="address"[^>]*>(.*?)</p>', block, re.DOTALL)
-        link_m = re.search(
-            r'href="([^"]*applicationDetails[^"]*)"[^>]*>(.*?)</a>', block, re.DOTALL
-        )
-        if not (meta_m and link_m):
-            continue
-
-        meta = re.sub(r"<[^>]+>", "", meta_m.group(1)).strip()
-        description = re.sub(r"<[^>]+>", "", link_m.group(2)).strip()
-        address = re.sub(r"<[^>]+>", "", addr_m.group(1)).strip() if addr_m else ""
-
-        reference = ""
-        date_received: date | None = None
-        status = ""
-        for part in meta.split("|"):
-            part = part.strip()
-            if part.startswith("Ref. No:"):
-                reference = part[len("Ref. No:") :].strip()
-            elif part.startswith("Received:"):
-                raw = re.sub(r"^[A-Za-z]{3}\s+", "", part[len("Received:") :].strip())
-                try:
-                    date_received = datetime.strptime(raw, "%d %b %Y").date()
-                except ValueError:
-                    pass
-            elif part.startswith("Status:"):
-                status = part[len("Status:") :].strip()
-
-        url = link_m.group(1).strip()
-        if not url.startswith("http"):
-            url = f"https://planning.eastdunbarton.gov.uk{url}"
-
-        applications.append(
-            PlanningApplication(
-                reference=reference,
-                address=address,
-                description=description,
-                date_received=date_received,
-                status=status,
-                url=url,
-            )
-        )
-    return applications
-
-
-async def _bulk_geocode(session, postcodes: list[str]) -> dict[str, tuple[float, float]]:
-    result: dict[str, tuple[float, float]] = {}
-    for i in range(0, len(postcodes), 100):
-        batch = postcodes[i : i + 100]
-        async with session.post(f"{_POSTCODES_IO}/postcodes", json={"postcodes": batch}) as resp:
-            resp.raise_for_status()
-            data = await resp.json()
-        for item in data.get("result", []):
-            if item.get("result"):
-                r = item["result"]
-                result[item["query"]] = (r["latitude"], r["longitude"])
-    return result
-
-
-def _extract_postcode(address: str) -> str | None:
-    m = _UK_POSTCODE_RE.search(address)
-    if not m:
+def _parse_feature(attrs: dict, distance_m: int) -> PlanningApplication | None:
+    keyval = attrs.get("KEYVAL", "")
+    if not keyval:
         return None
-    pc = m.group(1).upper().replace(" ", "")
-    return f"{pc[:-3]} {pc[-3:]}"
-
-
-def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    r = 6_371_000.0
-    phi1, phi2 = math.radians(lat1), math.radians(lat2)
-    dphi = math.radians(lat2 - lat1)
-    dlam = math.radians(lon2 - lon1)
-    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
-    return r * 2 * math.asin(math.sqrt(a))
+    reference = attrs.get("REFVAL") or keyval
+    address = attrs.get("ADDRESS", "").replace("\r", ", ").strip(", ")
+    description = attrs.get("DESCRIPTION", "")
+    date_modified: date | None = None
+    raw = attrs.get("DATEMODIFIED")
+    if isinstance(raw, (int, float)):
+        try:
+            date_modified = datetime.utcfromtimestamp(raw / 1000).date()
+        except (OSError, OverflowError, ValueError):
+            pass
+    url = (
+        "https://planning.eastdunbarton.gov.uk/online-applications/"
+        f"applicationDetails.do?activeTab=summary&keyVal={keyval}"
+    )
+    return PlanningApplication(
+        reference=reference,
+        address=address,
+        description=description,
+        date_modified=date_modified,
+        url=url,
+        distance_m=distance_m,
+    )

--- a/custom_components/east_dunbartonshire/planning.py
+++ b/custom_components/east_dunbartonshire/planning.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
+from math import asin, cos, radians, sin, sqrt
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -34,6 +34,8 @@ class PlanningApplication:
     date_modified: date | None
     url: str
     distance_m: int | None = None
+    latitude: float | None = None
+    longitude: float | None = None
 
 
 @dataclass
@@ -69,11 +71,22 @@ class PlanningCoordinator(DataUpdateCoordinator[PlanningData]):
                 self._easting, self._northing = await _latlon_to_bng(
                     self.session, self._lat, self._lon
                 )
+            easting: int = self._easting
+            northing: int = self._northing  # type: ignore[assignment]
             return await _fetch_nearby(
-                self.session, self._easting, self._northing, self._radius_m
+                self.session, easting, northing, self._lat, self._lon, self._radius_m
             )
         except Exception as err:
             raise UpdateFailed(f"Error fetching planning applications: {err}") from err
+
+
+def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    r = 6_371_000.0
+    phi1, phi2 = radians(lat1), radians(lat2)
+    dphi = radians(lat2 - lat1)
+    dlam = radians(lon2 - lon1)
+    a = sin(dphi / 2) ** 2 + cos(phi1) * cos(phi2) * sin(dlam / 2) ** 2
+    return r * 2 * asin(sqrt(a))
 
 
 async def _latlon_to_bng(session, lat: float, lon: float) -> tuple[int, int]:
@@ -91,7 +104,12 @@ async def _latlon_to_bng(session, lat: float, lon: float) -> tuple[int, int]:
 
 
 async def _fetch_nearby(
-    session, home_easting: int, home_northing: int, radius_m: int
+    session,
+    home_easting: int,
+    home_northing: int,
+    home_lat: float,
+    home_lon: float,
+    radius_m: int,
 ) -> PlanningData:
     bbox = {
         "xmin": home_easting - radius_m,
@@ -104,7 +122,7 @@ async def _fetch_nearby(
         "geometry": json.dumps(bbox, separators=(",", ":")),
         "geometryType": "esriGeometryEnvelope",
         "inSR": "27700",
-        "outSR": "27700",
+        "outSR": "4326",
         "spatialRel": "esriSpatialRelIntersects",
         "where": "ISPAVISIBLE=1",
         "outFields": "REFVAL,KEYVAL,ADDRESS,DESCRIPTION,DATEMODIFIED",
@@ -124,12 +142,12 @@ async def _fetch_nearby(
         centroid = feature.get("centroid")
         if not centroid:
             continue
-        dist = math.sqrt(
-            (centroid["x"] - home_easting) ** 2 + (centroid["y"] - home_northing) ** 2
-        )
+        # outSR=4326: centroid x=longitude, y=latitude
+        app_lon, app_lat = centroid["x"], centroid["y"]
+        dist = _haversine_m(home_lat, home_lon, app_lat, app_lon)
         if dist > radius_m:
             continue
-        app = _parse_feature(attrs, round(dist))
+        app = _parse_feature(attrs, round(dist), app_lat, app_lon)
         if app:
             nearby.append(app)
 
@@ -137,7 +155,9 @@ async def _fetch_nearby(
     return PlanningData(applications=nearby, search_radius_m=radius_m)
 
 
-def _parse_feature(attrs: dict, distance_m: int) -> PlanningApplication | None:
+def _parse_feature(
+    attrs: dict, distance_m: int, latitude: float, longitude: float
+) -> PlanningApplication | None:
     keyval = attrs.get("KEYVAL", "")
     if not keyval:
         return None
@@ -162,4 +182,6 @@ def _parse_feature(attrs: dict, distance_m: int) -> PlanningApplication | None:
         date_modified=date_modified,
         url=url,
         distance_m=distance_m,
+        latitude=latitude,
+        longitude=longitude,
     )

--- a/custom_components/east_dunbartonshire/sensor.py
+++ b/custom_components/east_dunbartonshire/sensor.py
@@ -30,8 +30,7 @@ async def async_setup_entry(
     data = hass.data[DOMAIN]
     coordinator: EastDunbartonshireCoordinator = data[entry.entry_id]
     entities: list[SensorEntity] = [
-        BinSensor(coordinator, entry, bin_class, name)
-        for bin_class, name in BIN_TYPES.items()
+        BinSensor(coordinator, entry, bin_class, name) for bin_class, name in BIN_TYPES.items()
     ]
     if "school_holidays" in data:
         entities.append(SchoolHolidayYearsSensor(data["school_holidays"]))
@@ -91,9 +90,7 @@ class BinSensor(CoordinatorEntity[EastDunbartonshireCoordinator], SensorEntity):
 # ---------------------------------------------------------------------------
 
 
-class SchoolHolidayYearsSensor(
-    CoordinatorEntity[SchoolHolidaysCoordinator], SensorEntity
-):
+class SchoolHolidayYearsSensor(CoordinatorEntity[SchoolHolidaysCoordinator], SensorEntity):
     """Tracks which academic years' data is available. Automating on state change detects new releases."""
 
     _attr_has_entity_name = True
@@ -143,9 +140,7 @@ class PlanningApplicationsSensor(CoordinatorEntity[PlanningCoordinator], SensorE
                     "reference": a.reference,
                     "address": a.address,
                     "description": a.description,
-                    "date_modified": (
-                        a.date_modified.isoformat() if a.date_modified else None
-                    ),
+                    "date_modified": (a.date_modified.isoformat() if a.date_modified else None),
                     "distance_m": a.distance_m,
                     "url": a.url,
                 }

--- a/custom_components/east_dunbartonshire/sensor.py
+++ b/custom_components/east_dunbartonshire/sensor.py
@@ -30,7 +30,8 @@ async def async_setup_entry(
     data = hass.data[DOMAIN]
     coordinator: EastDunbartonshireCoordinator = data[entry.entry_id]
     entities: list[SensorEntity] = [
-        BinSensor(coordinator, entry, bin_class, name) for bin_class, name in BIN_TYPES.items()
+        BinSensor(coordinator, entry, bin_class, name)
+        for bin_class, name in BIN_TYPES.items()
     ]
     if "school_holidays" in data:
         entities.append(SchoolHolidayYearsSensor(data["school_holidays"]))
@@ -90,7 +91,9 @@ class BinSensor(CoordinatorEntity[EastDunbartonshireCoordinator], SensorEntity):
 # ---------------------------------------------------------------------------
 
 
-class SchoolHolidayYearsSensor(CoordinatorEntity[SchoolHolidaysCoordinator], SensorEntity):
+class SchoolHolidayYearsSensor(
+    CoordinatorEntity[SchoolHolidaysCoordinator], SensorEntity
+):
     """Tracks which academic years' data is available. Automating on state change detects new releases."""
 
     _attr_has_entity_name = True
@@ -140,8 +143,9 @@ class PlanningApplicationsSensor(CoordinatorEntity[PlanningCoordinator], SensorE
                     "reference": a.reference,
                     "address": a.address,
                     "description": a.description,
-                    "date_received": a.date_received.isoformat() if a.date_received else None,
-                    "status": a.status,
+                    "date_modified": (
+                        a.date_modified.isoformat() if a.date_modified else None
+                    ),
                     "distance_m": a.distance_m,
                     "url": a.url,
                 }


### PR DESCRIPTION
## Summary

- Adds `geo_location` entities for each nearby planning application — they appear as individual pins on the HA map card
- Changes ArcGIS query to return centroids in WGS84 (`outSR=4326`) rather than BNG, so coordinates are stored directly on each `PlanningApplication`
- Distance calculation updated to haversine (matching the coordinate system)
- `_PlanningGeoManager` handles entity lifecycle: adds new applications, removes ones that leave the radius, updates existing on each coordinator refresh
- `Platform.GEO_LOCATION` added to `PLATFORMS`

## Test plan

- [ ] After HA restart, planning application pins appear on the map card within the configured radius
- [ ] After coordinator refresh, stale pins are removed and new ones appear
- [ ] `sensor.nearby_planning_applications` count still matches the number of map pins