### PR TITLE
fix: add issues:write permission to integration test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 8 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- The scheduled integration test workflow was failing when trying to open an issue on failure
- The GITHUB_TOKEN only had `contents: read` permission by default — missing `issues: write`
- Added explicit `permissions` block to grant the workflow the access it needs

## Test plan
- [ ] Verify the next scheduled run (or a manual trigger) successfully opens an issue on failure instead of erroring on label creation