### PR TITLE
feat: planning applications map pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,130 @@ Once configured, the integration creates:
 - **Calendar** — shows upcoming bin collection events; works with the Home Assistant calendar card
 - **Sensors** — one per bin type (Food caddy, Green bin, Grey bin), showing the date of the next collection with a `days_until` attribute
 - **Geo location entities** — one per nearby planning application (within your configured search radius), shown as map pins; each entity includes `address`, `description`, `date_modified`, and `url` attributes
+
+## Example automations
+
+These examples use the `east_dunbartonshire_planning` source to identify planning application geo location entities. Replace `notify.mobile_app_your_phone` with your own notification service.
+
+### Alert when a new application appears
+
+Triggers whenever a new planning application geo location entity is created (i.e. a fresh application enters your search radius).
+
+```yaml
+automation:
+  - alias: "New nearby planning application"
+    trigger:
+      - platform: event
+        event_type: state_changed
+    condition:
+      - condition: template
+        value_template: >
+          {{ trigger.event.data.entity_id.startswith('geo_location.')
+             and trigger.event.data.new_state is not none
+             and trigger.event.data.new_state.attributes.get('source') == 'east_dunbartonshire_planning'
+             and trigger.event.data.old_state is none }}
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "New planning application nearby"
+          message: >
+            {{ trigger.event.data.new_state.name }}
+            {{ trigger.event.data.new_state.attributes.address }}
+            {{ trigger.event.data.new_state.attributes.description }}
+          data:
+            url: "{{ trigger.event.data.new_state.attributes.url }}"
+```
+
+### Weekly digest
+
+Sends a summary every Monday morning listing all current nearby applications.
+
+```yaml
+automation:
+  - alias: "Weekly planning applications digest"
+    trigger:
+      - platform: time
+        at: "09:00:00"
+    condition:
+      - condition: time
+        weekday:
+          - mon
+      - condition: template
+        value_template: >
+          {{ states.geo_location
+             | selectattr('attributes.source', 'eq', 'east_dunbartonshire_planning')
+             | list | count > 0 }}
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Nearby planning applications"
+          message: >
+            {% set apps = states.geo_location
+               | selectattr('attributes.source', 'eq', 'east_dunbartonshire_planning')
+               | sort(attribute='attributes.date_modified', reverse=True) | list %}
+            {{ apps | count }} application(s) in the last 90 days:
+            {% for app in apps %}
+            - {{ app.name }}: {{ app.attributes.address }} ({{ app.attributes.date_modified }})
+            {% endfor %}
+```
+
+### Alert for specific application types
+
+Notifies only when the application description matches keywords you care about (e.g. extensions, new builds).
+
+```yaml
+automation:
+  - alias: "Planning application keyword alert"
+    trigger:
+      - platform: event
+        event_type: state_changed
+    condition:
+      - condition: template
+        value_template: >
+          {% set desc = trigger.event.data.new_state.attributes.get('description', '') | lower %}
+          {{ trigger.event.data.entity_id.startswith('geo_location.')
+             and trigger.event.data.new_state is not none
+             and trigger.event.data.new_state.attributes.get('source') == 'east_dunbartonshire_planning'
+             and trigger.event.data.old_state is none
+             and desc is search('dwellinghouse|extension|erection|conversion') }}
+    action:
+      - service: notify.mobile_app_your_phone
+        data:
+          title: "Planning application: residential works nearby"
+          message: >
+            {{ trigger.event.data.new_state.name }}
+            {{ trigger.event.data.new_state.attributes.address }}
+            {{ trigger.event.data.new_state.attributes.description }}
+          data:
+            url: "{{ trigger.event.data.new_state.attributes.url }}"
+```
+
+### Persistent notification in the HA dashboard
+
+Creates a dismissible notification in the Home Assistant UI for each new application.
+
+```yaml
+automation:
+  - alias: "Planning application persistent notification"
+    trigger:
+      - platform: event
+        event_type: state_changed
+    condition:
+      - condition: template
+        value_template: >
+          {{ trigger.event.data.entity_id.startswith('geo_location.')
+             and trigger.event.data.new_state is not none
+             and trigger.event.data.new_state.attributes.get('source') == 'east_dunbartonshire_planning'
+             and trigger.event.data.old_state is none }}
+    action:
+      - service: persistent_notification.create
+        data:
+          title: "Planning application: {{ trigger.event.data.new_state.name }}"
+          message: >
+            **{{ trigger.event.data.new_state.attributes.address }}**
+
+            {{ trigger.event.data.new_state.attributes.description }}
+
+            [View application]({{ trigger.event.data.new_state.attributes.url }})
+          notification_id: "planning_{{ trigger.event.data.new_state.name }}"
+```

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ A [Home Assistant](https://www.home-assistant.io/) custom integration for East D
 ## Features
 
 - **Bin collections** — sensors and calendar for upcoming bin collection dates, looked up by address
-
-More features planned: school holidays, planning applications, and more.
+- **Planning applications** — nearby planning applications shown as map pins, filtered to applications modified in the last 90 days
 
 ## Installation
 
@@ -33,3 +32,4 @@ Once configured, the integration creates:
 
 - **Calendar** — shows upcoming bin collection events; works with the Home Assistant calendar card
 - **Sensors** — one per bin type (Food caddy, Green bin, Grey bin), showing the date of the next collection with a `days_until` attribute
+- **Geo location entities** — one per nearby planning application (within your configured search radius), shown as map pins; each entity includes `address`, `description`, `date_modified`, and `url` attributes

--- a/custom_components/east_dunbartonshire/planning.py
+++ b/custom_components/east_dunbartonshire/planning.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from math import asin, cos, radians, sin, sqrt
 
 from homeassistant.core import HomeAssistant
@@ -129,7 +129,7 @@ async def _fetch_nearby(
             "ISPAVISIBLE=1 AND DATEMODIFIED>="
             + str(
                 int(
-                    (datetime.now(timezone.utc) - timedelta(days=_RECENT_DAYS)).timestamp()
+                    (datetime.now(UTC) - timedelta(days=_RECENT_DAYS)).timestamp()
                     * 1000
                 )
             )

--- a/custom_components/east_dunbartonshire/planning.py
+++ b/custom_components/east_dunbartonshire/planning.py
@@ -118,9 +118,7 @@ async def _fetch_nearby(
         "xmax": home_easting + radius_m,
         "ymax": home_northing + radius_m,
     }
-    cutoff_ms = int(
-        (datetime.now(UTC) - timedelta(days=_RECENT_DAYS)).timestamp() * 1000
-    )
+    cutoff_ms = int((datetime.now(UTC) - timedelta(days=_RECENT_DAYS)).timestamp() * 1000)
     params = {
         "f": "json",
         "geometry": json.dumps(bbox, separators=(",", ":")),

--- a/custom_components/east_dunbartonshire/planning.py
+++ b/custom_components/east_dunbartonshire/planning.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from math import asin, cos, radians, sin, sqrt
 
 from homeassistant.core import HomeAssistant
@@ -24,6 +24,7 @@ _ARCGIS_REFERER = (
 )
 _POSTCODES_IO_REVERSE = "https://api.postcodes.io/postcodes"
 DEFAULT_RADIUS_M = 500
+_RECENT_DAYS = 90
 
 
 @dataclass
@@ -124,7 +125,15 @@ async def _fetch_nearby(
         "inSR": "27700",
         "outSR": "4326",
         "spatialRel": "esriSpatialRelIntersects",
-        "where": "ISPAVISIBLE=1",
+        "where": (
+            "ISPAVISIBLE=1 AND DATEMODIFIED>="
+            + str(
+                int(
+                    (datetime.now(timezone.utc) - timedelta(days=_RECENT_DAYS)).timestamp()
+                    * 1000
+                )
+            )
+        ),
         "outFields": "REFVAL,KEYVAL,ADDRESS,DESCRIPTION,DATEMODIFIED",
         "returnGeometry": "false",
         "returnCentroid": "true",

--- a/custom_components/east_dunbartonshire/planning.py
+++ b/custom_components/east_dunbartonshire/planning.py
@@ -118,6 +118,9 @@ async def _fetch_nearby(
         "xmax": home_easting + radius_m,
         "ymax": home_northing + radius_m,
     }
+    cutoff_ms = int(
+        (datetime.now(UTC) - timedelta(days=_RECENT_DAYS)).timestamp() * 1000
+    )
     params = {
         "f": "json",
         "geometry": json.dumps(bbox, separators=(",", ":")),
@@ -125,15 +128,7 @@ async def _fetch_nearby(
         "inSR": "27700",
         "outSR": "4326",
         "spatialRel": "esriSpatialRelIntersects",
-        "where": (
-            "ISPAVISIBLE=1 AND DATEMODIFIED>="
-            + str(
-                int(
-                    (datetime.now(UTC) - timedelta(days=_RECENT_DAYS)).timestamp()
-                    * 1000
-                )
-            )
-        ),
+        "where": f"ISPAVISIBLE=1 AND DATEMODIFIED>={cutoff_ms}",
         "outFields": "REFVAL,KEYVAL,ADDRESS,DESCRIPTION,DATEMODIFIED",
         "returnGeometry": "false",
         "returnCentroid": "true",


### PR DESCRIPTION
## Summary

- Adds geo location entities for nearby planning applications, shown as map pins on the HA map
- Queries the East Dunbartonshire ArcGIS planning portal within a configurable radius
- Filters to applications modified in the last 90 days so only recent/active applications appear
- Adds example automations to the README (new application alerts, weekly digest, keyword filtering, persistent notifications)

## Test plan

- [ ] Geo location entities appear on the HA map for nearby applications
- [ ] Old applications (e.g. from 2021) no longer appear after the 90-day filter
- [ ] Entities are removed when they fall outside the search radius or age window
- [ ] Example automations are syntactically valid YAML