### PR TITLE
fix: add brown and blue bin types

### DIFF
--- a/custom_components/east_dunbartonshire/const.py
+++ b/custom_components/east_dunbartonshire/const.py
@@ -9,4 +9,6 @@ BIN_TYPES = {
     "food-caddy": "Food caddy",
     "garden-bin": "Green bin",
     "rubbish-bin": "Grey bin",
+    "plastic-bin": "Brown bin",
+    "recycling-bin": "Blue bin",
 }


### PR DESCRIPTION
## Summary

- Adds `plastic-bin` (Brown bin) and `recycling-bin` (Blue bin) to `BIN_TYPES`
- The ED collections page only shows the next few upcoming collections, so blue/brown bins may not appear on every poll — but when they do, the component will now create sensors for them

Discovered by checking a different UPRN (`132002413`) which showed all 5 bin types:
- `food-caddy` — Food caddy
- `garden-bin` — Green bin
- `rubbish-bin` — Grey bin
- `plastic-bin` — Brown bin
- `recycling-bin` — Blue bin

## Test plan

- [ ] Blue and brown bin sensors appear once those bin types are returned by the API for a given UPRN