### PR TITLE
chore: align ruff config to shared standard

### DIFF
--- a/custom_components/east_dunbartonshire/planning.py
+++ b/custom_components/east_dunbartonshire/planning.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from dataclasses import dataclass, field
@@ -169,10 +170,8 @@ def _parse_feature(
     date_modified: date | None = None
     raw = attrs.get("DATEMODIFIED")
     if isinstance(raw, (int, float)):
-        try:
+        with contextlib.suppress(OSError, OverflowError, ValueError):
             date_modified = datetime.utcfromtimestamp(raw / 1000).date()
-        except (OSError, OverflowError, ValueError):
-            pass
     url = (
         "https://planning.eastdunbarton.gov.uk/online-applications/"
         f"applicationDetails.do?activeTab=summary&keyVal={keyval}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,17 +12,14 @@ target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
-select = [
-    "E",   # pycodestyle errors
-    "F",   # pyflakes
-    "I",   # isort
-    "UP",  # pyupgrade
-    "RUF", # ruff-specific
-]
+select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]
 ignore = [
-    "E501",   # line too long — handled by formatter
-    "RUF012", # mutable class attrs are idiomatic in HA entities
+    "E501",   # line length is enforced by the formatter
+    "RUF012", # mutable class attributes are idiomatic in HA entities
 ]
+
+[tool.ruff.format]
+quote-style = "double"
 
 [tool.ruff.lint.isort]
 known-first-party = ["custom_components.east_dunbartonshire"]


### PR DESCRIPTION
Aligns this repo's ruff configuration with the shared canonical standard.

## Changes
- Add `B` (flake8-bugbear) and `SIM` (flake8-simplify) rule sets to `[tool.ruff.lint].select`.
- Add an explicit `[tool.ruff.format]` block with `quote-style = "double"`.
- Normalise `ignore` comments to canonical wording.
- Preserve the repo-specific `[tool.ruff.lint.isort] known-first-party` (`custom_components.east_dunbartonshire`).
- Resolve the single resulting `SIM105` finding in `planning.py` by using `contextlib.suppress` instead of `try`/`except`/`pass` (behaviour-preserving).

CI already ran both `ruff check` and `ruff format --check` (`.github/workflows/lint.yml`), so no CI changes were needed.

Local results: `ruff check .` and `ruff format --check .` both pass.